### PR TITLE
Name the example inf iterator of iterators sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We should explore how to make this more ergonomic and functional.
 let digits = Iterator.concat(lows, [4, 5], highs);
 ```
 
-For the (rare) case of infinite iterators of iterators, use the existing [`flatMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/flatMap) with the identity function.
+For the (rare) case of infinite iterators of iterators, use [`Iterator.prototype.flatMap`](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-iterator.prototype.flatmap) with the identity function.
 
 ```js
 function* self_counting_sequence_helper() {

--- a/README.md
+++ b/README.md
@@ -56,15 +56,15 @@ We should explore how to make this more ergonomic and functional.
 let digits = Iterator.concat(lows, [4, 5], highs);
 ```
 
-For the (rare) case of infinite iterators of iterators, use `flatMap` with the identity function.
+For the (rare) case of infinite iterators of iterators, use the existing [`flatMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/flatMap) with the identity function.
 
 ```js
-function* p() {
+function* self_counting_sequence_helper() {
   for (let n = 1;; ++n) {
     yield Array(n).fill(n);
   }
 }
-let repeatedNats = p().flatMap(x => x);
+let self_counting_sequence = self_counting_sequence_helper().flatMap(x => x)
 ```
 
 ## prior art

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ let digits = Iterator.concat(lows, [4, 5], highs);
 For the (rare) case of infinite iterators of iterators, use [`Iterator.prototype.flatMap`](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-iterator.prototype.flatmap) with the identity function.
 
 ```js
-function* self_counting_sequence_helper() {
+function* selfCountingSequenceHelper() {
   for (let n = 1;; ++n) {
     yield Array(n).fill(n);
   }
 }
-let self_counting_sequence = self_counting_sequence_helper().flatMap(x => x)
+let selfCountingSequence = selfCountingSequenceHelper().flatMap(x => x)
 ```
 
 ## prior art


### PR DESCRIPTION
Calling the helper function p() is a bit confusing because the p-series is a kinda well-known infinite series, and the example function isn't for that series. The p series is 1 + 1/(2^p) + 1/(3^p) + ...

The example sequence is https://oeis.org/A002024. I picked a name for the functions from the references listed by the Online Encyclopedia of Integer Sequences.

As an unrelated change, I've added a link to MDN for `flatMap`, because I didn't know that it existed for iterators, or precisely what it does.