### PR TITLE
updates from May 2025 plenary

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -25,18 +25,11 @@ copyright: false
         1. Let _iteratorRecord_ be ? GetIteratorDirect(_iter_).
         1. Let _innerAlive_ be *true*.
         1. Repeat, while _innerAlive_ is *true*,
-          1. Let _iteratorResult_ be ? IteratorNext(_iteratorRecord_).
-          1. Let _done_ be Completion(IteratorComplete(_iteratorResult_)).
-          1. If _done_ is a throw completion, then
-            1. Set _iteratorRecord_.[[Done]] to *true*.
-            1. Return ? _done_.
-          1. Set _done_ to ! _done_.
-          1. If _done_ is *true*, then
-            1. Set _iteratorRecord_.[[Done]] to *true*.
-            1. Perform ? IteratorValue(_iteratorResult_).
+          1. Let _innerValue_ be ? IteratorStepValue(_iteratorRecord_).
+          1. If _innerValue_ is ~done~, then
             1. Set _innerAlive_ to *false*.
           1. Else,
-            1. Let _completion_ be Completion(GeneratorYield(_iteratorResult_)).
+            1. Let _completion_ be Completion(Yield(_innerValue_)).
             1. If _completion_ is an abrupt completion, then
               1. Return ? IteratorClose(_iteratorRecord_, _completion_).
       1. Return ReturnCompletion(*undefined*).


### PR DESCRIPTION
This effectively reverts #19/#23 (reading the last IteratorResult value) and #18 (re-using IteratorResult objects).